### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "pixline/wp-cli-php-devtools",
-  "type": "command",
+  "type": "wp-cli-package",
   "description": "Wrapper around common development utilities",
   "keywords": ["wp-cli","phpcpd","phpcs","phpdcd","phploc","phpmd","phpunit","phpreport","development"],
   "homepage": "https://github.com/pixline/wp-cli-php-devtools",


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
